### PR TITLE
Makefile targets in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,38 @@ Additionally this service exposes several metrics about consumed and processed
 messages. These metrics can be aggregated by Prometheus and displayed by
 Grafana tools.
 
+## Building
+
+Use `make build` to build executable file with this service.
+
+All Makefile targets:
+
+```
+Usage: make <OPTIONS> ... <TARGETS>
+
+Available targets are:
+
+clean                Run go clean
+build                Keep this rule for compatibility
+fmt                  Run go fmt -w for all sources
+lint                 Run golint
+vet                  Run go vet. Report likely mistakes in source code
+cyclo                Run gocyclo
+ineffassign          Run ineffassign checker
+shellcheck           Run shellcheck
+errcheck             Run errcheck
+goconst              Run goconst checker
+gosec                Run gosec checker
+abcgo                Run ABC metrics checker
+json-check           Check all JSONs for basic syntax
+style                Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
+run                  Build the project and executes the binary
+test                 Run the unit tests
+bdd_tests            Run BDD tests
+before_commit        Checks done before commit
+help                 Show this help screen
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
# Description

Makefile targets in README.md

Fixes #65

## Type of change

- Documentation update

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
