### PR TITLE
Ability to cleanup old records from new reports table

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ help                 Show this help screen
         drop all tables from database
   -db-init
         perform database initialization
+  -max-age string
+        max age for displaying/cleaning old records
+  -new-reports-cleanup
+        perform new reports clean up
+  -print-new-reports-for-cleanup
+        print new reports to be cleaned up
   -show-configuration
         show configuration
   -version

--- a/ccx_notification_writer.go
+++ b/ccx_notification_writer.go
@@ -187,13 +187,13 @@ func printNewReportsForCleanup(config ConfigStruct, cliFlags CliFlags) (int, err
 	storageConfiguration := GetStorageConfiguration(config)
 	storage, err := NewStorage(storageConfiguration)
 	if err != nil {
-		log.Err(err).Msg(operationFailedMessage)
+		log.Error().Err(err).Msg(operationFailedMessage)
 		return ExitStatusStorageError, err
 	}
 
 	err = storage.PrintNewReportsForCleanup(cliFlags.maxAge)
 	if err != nil {
-		log.Err(err).Msg(databasePrintNewReportsForCleanupOperationFailedMessage)
+		log.Error().Err(err).Msg(databasePrintNewReportsForCleanupOperationFailedMessage)
 		return ExitStatusStorageError, err
 	}
 
@@ -205,15 +205,16 @@ func performNewReportsCleanup(config ConfigStruct, cliFlags CliFlags) (int, erro
 	storageConfiguration := GetStorageConfiguration(config)
 	storage, err := NewStorage(storageConfiguration)
 	if err != nil {
-		log.Err(err).Msg(operationFailedMessage)
+		log.Error().Err(err).Msg(operationFailedMessage)
 		return ExitStatusStorageError, err
 	}
 
-	err = storage.CleanupNewReports(cliFlags.maxAge)
+	affected, err := storage.CleanupNewReports(cliFlags.maxAge)
 	if err != nil {
-		log.Err(err).Msg(databaseCleanupNewRepoprtsOperationFailedMessage)
+		log.Error().Err(err).Msg(databaseCleanupNewRepoprtsOperationFailedMessage)
 		return ExitStatusStorageError, err
 	}
+	log.Info().Int("Rows deleted", affected).Msg("Cleanup `new_reports` finished")
 
 	return ExitStatusOK, nil
 }

--- a/storage.go
+++ b/storage.go
@@ -183,8 +183,9 @@ const (
 	AccountNumberMessage      = "Account number"
 	ClusterNameMessage        = "Cluster name"
 	UpdatedAtMessage          = "Updated at"
-	AgeMessage                = "Age"
 	UnableToCloseDBRowsHandle = "Unable to close the DB rows handle"
+	AgeMessage                = "Age"
+	MaxAgeAttribute           = "max age"
 )
 
 // Storage represents an interface to almost any database or storage system
@@ -522,7 +523,7 @@ func (storage DBStorage) GetLatestKafkaOffset() (KafkaOffset, error) {
 // relative time
 func (storage DBStorage) PrintNewReportsForCleanup(maxAge string) error {
 	log.Info().
-		Str("max age", maxAge).
+		Str(MaxAgeAttribute, maxAge).
 		Str("select statement", displayOldRecordsFromNewReportsTable).
 		Msg("PrintNewReportsForCleanup operation")
 
@@ -575,7 +576,7 @@ func (storage DBStorage) PrintNewReportsForCleanup(maxAge string) error {
 // relative time
 func (storage DBStorage) CleanupNewReports(maxAge string) (int, error) {
 	log.Info().
-		Str("max age", maxAge).
+		Str(MaxAgeAttribute, maxAge).
 		Str("delete statement", deleteOldRecordsFromNewReportsTable).
 		Msg("CleanupNewReports operation")
 

--- a/types.go
+++ b/types.go
@@ -35,6 +35,9 @@ type CliFlags struct {
 	showVersion                   bool
 	showAuthors                   bool
 	showConfiguration             bool
+	printNewReportsForCleanup     bool
+	performNewReportsCleanup      bool
+	maxAge                        string
 }
 
 // RequestID data type is used to store the request ID supplied in input Kafka


### PR DESCRIPTION
# Description

Ability to cleanup old records from new reports table

Fixes #59

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
