### PR TITLE
Ability to cleanup old records from `reported` table

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,48 @@ help                 Show this help screen
         max age for displaying/cleaning old records
   -new-reports-cleanup
         perform new reports clean up
+  -old-reports-cleanup
+        perform old reports clean up
   -print-new-reports-for-cleanup
         print new reports to be cleaned up
+  -print-old-reports-for-cleanup
+        print old reports to be cleaned up
   -show-configuration
         show configuration
   -version
         show version
 ```
+
+## Starting the service
+
+In order to start the service, just `./ccx-notification-writer` is needed to be called from CLI.
+
+## Cleanup old records
+
+It is possible to cleanup old records from `new_reports` and `reported` tables. To do it, use the following CLI options:
+
+```
+./ccx-notification-writer -old-reports-cleanup --max-age="30 days"
+```
+
+or
+
+```
+./ccx-notification-writer -new-reports-cleanup --max-age="30 days"
+```
+
+Additionally it is possible to just display old reports without touching the database tables:
+
+```
+./ccx-notification-writer -print-old-reports-for-cleanup --max-age="30 days"
+```
+
+or
+
+```
+./ccx-notification-writer -print-new-reports-for-cleanup --max-age="30 days"
+```
+
 
 ## Metrics
 

--- a/ccx_notification_writer.go
+++ b/ccx_notification_writer.go
@@ -55,6 +55,7 @@ const (
 	databasePrintOldReportsForCleanupOperationFailedMessage = "Print records from `reported` table prepared for cleanup failed"
 	databaseCleanupNewReportsOperationFailedMessage         = "Cleanup records from `new_reports` table failed"
 	databaseCleanupOldReportsOperationFailedMessage         = "Cleanup records from `reported` table failed"
+	rowsDeletedMessage                                      = "Rows deleted"
 )
 
 // Configuration-related constants
@@ -220,7 +221,7 @@ func performNewReportsCleanup(config ConfigStruct, cliFlags CliFlags) (int, erro
 		log.Error().Err(err).Msg(databaseCleanupNewReportsOperationFailedMessage)
 		return ExitStatusStorageError, err
 	}
-	log.Info().Int("Rows deleted", affected).Msg("Cleanup `new_reports` finished")
+	log.Info().Int(rowsDeletedMessage, affected).Msg("Cleanup `new_reports` finished")
 
 	return ExitStatusOK, nil
 }
@@ -261,7 +262,7 @@ func performOldReportsCleanup(config ConfigStruct, cliFlags CliFlags) (int, erro
 		log.Error().Err(err).Msg(databaseCleanupOldReportsOperationFailedMessage)
 		return ExitStatusStorageError, err
 	}
-	log.Info().Int("Rows deleted", affected).Msg("Cleanup `reported` finished")
+	log.Info().Int(rowsDeletedMessage, affected).Msg("Cleanup `reported` finished")
 
 	return ExitStatusOK, nil
 }

--- a/ccx_notification_writer.go
+++ b/ccx_notification_writer.go
@@ -51,8 +51,10 @@ const (
 	brokerConnectionSuccessMessage                          = "Broker connection OK"
 	databaseCleanupOperationFailedMessage                   = "Database cleanup operation failed"
 	databaseDropTablesOperationFailedMessage                = "Database drop tables operation failed"
-	databasePrintNewReportsForCleanupOperationFailedMessage = "Print records from `new_reports` prepared for cleanup failed"
-	databaseCleanupNewRepoprtsOperationFailedMessage        = "Cleanup records from `new_reports` failed"
+	databasePrintNewReportsForCleanupOperationFailedMessage = "Print records from `new_reports` table prepared for cleanup failed"
+	databasePrintOldReportsForCleanupOperationFailedMessage = "Print records from `reported` table prepared for cleanup failed"
+	databaseCleanupNewReportsOperationFailedMessage         = "Cleanup records from `new_reports` table failed"
+	databaseCleanupOldReportsOperationFailedMessage         = "Cleanup records from `reported` table failed"
 )
 
 // Configuration-related constants
@@ -182,6 +184,8 @@ func performDatabaseDropTables(config ConfigStruct) (int, error) {
 	return ExitStatusOK, nil
 }
 
+// printNewReportsForCleanup function print all reports for `new_reports` table
+// that are older than specified max age.
 func printNewReportsForCleanup(config ConfigStruct, cliFlags CliFlags) (int, error) {
 	// prepare the storage
 	storageConfiguration := GetStorageConfiguration(config)
@@ -200,6 +204,8 @@ func printNewReportsForCleanup(config ConfigStruct, cliFlags CliFlags) (int, err
 	return ExitStatusOK, nil
 }
 
+// performNewReportsCleanup function deletes all reports from `new_reports`
+// table that are older than specified max age.
 func performNewReportsCleanup(config ConfigStruct, cliFlags CliFlags) (int, error) {
 	// prepare the storage
 	storageConfiguration := GetStorageConfiguration(config)
@@ -211,10 +217,51 @@ func performNewReportsCleanup(config ConfigStruct, cliFlags CliFlags) (int, erro
 
 	affected, err := storage.CleanupNewReports(cliFlags.maxAge)
 	if err != nil {
-		log.Error().Err(err).Msg(databaseCleanupNewRepoprtsOperationFailedMessage)
+		log.Error().Err(err).Msg(databaseCleanupNewReportsOperationFailedMessage)
 		return ExitStatusStorageError, err
 	}
 	log.Info().Int("Rows deleted", affected).Msg("Cleanup `new_reports` finished")
+
+	return ExitStatusOK, nil
+}
+
+// printOldReportsForCleanup function print all reports for `reported` table
+// that are older than specified max age.
+func printOldReportsForCleanup(config ConfigStruct, cliFlags CliFlags) (int, error) {
+	// prepare the storage
+	storageConfiguration := GetStorageConfiguration(config)
+	storage, err := NewStorage(storageConfiguration)
+	if err != nil {
+		log.Error().Err(err).Msg(operationFailedMessage)
+		return ExitStatusStorageError, err
+	}
+
+	err = storage.PrintOldReportsForCleanup(cliFlags.maxAge)
+	if err != nil {
+		log.Error().Err(err).Msg(databasePrintOldReportsForCleanupOperationFailedMessage)
+		return ExitStatusStorageError, err
+	}
+
+	return ExitStatusOK, nil
+}
+
+// performOldReportsCleanup function deletes all reports from `reported` table
+// that are older than specified max age.
+func performOldReportsCleanup(config ConfigStruct, cliFlags CliFlags) (int, error) {
+	// prepare the storage
+	storageConfiguration := GetStorageConfiguration(config)
+	storage, err := NewStorage(storageConfiguration)
+	if err != nil {
+		log.Error().Err(err).Msg(operationFailedMessage)
+		return ExitStatusStorageError, err
+	}
+
+	affected, err := storage.CleanupOldReports(cliFlags.maxAge)
+	if err != nil {
+		log.Error().Err(err).Msg(databaseCleanupOldReportsOperationFailedMessage)
+		return ExitStatusStorageError, err
+	}
+	log.Info().Int("Rows deleted", affected).Msg("Cleanup `reported` finished")
 
 	return ExitStatusOK, nil
 }
@@ -310,6 +357,10 @@ func doSelectedOperation(configuration ConfigStruct, cliFlags CliFlags) (int, er
 		return printNewReportsForCleanup(configuration, cliFlags)
 	case cliFlags.performNewReportsCleanup:
 		return performNewReportsCleanup(configuration, cliFlags)
+	case cliFlags.printOldReportsForCleanup:
+		return printOldReportsForCleanup(configuration, cliFlags)
+	case cliFlags.performOldReportsCleanup:
+		return performOldReportsCleanup(configuration, cliFlags)
 	default:
 		exitCode, err := startService(configuration)
 		return exitCode, err
@@ -331,6 +382,8 @@ func main() {
 	flag.BoolVar(&cliFlags.showConfiguration, "show-configuration", false, "show configuration")
 	flag.BoolVar(&cliFlags.printNewReportsForCleanup, "print-new-reports-for-cleanup", false, "print new reports to be cleaned up")
 	flag.BoolVar(&cliFlags.performNewReportsCleanup, "new-reports-cleanup", false, "perform new reports clean up")
+	flag.BoolVar(&cliFlags.printOldReportsForCleanup, "print-old-reports-for-cleanup", false, "print old reports to be cleaned up")
+	flag.BoolVar(&cliFlags.performOldReportsCleanup, "old-reports-cleanup", false, "perform old reports clean up")
 	flag.StringVar(&cliFlags.maxAge, "max-age", "", "max age for displaying/cleaning old records")
 	flag.Parse()
 

--- a/gocyclo.sh
+++ b/gocyclo.sh
@@ -28,7 +28,7 @@ then
     GO111MODULE=off go get github.com/fzipp/gocyclo/cmd/gocyclo
 fi
 
-if ! gocyclo -over 10 -avg .
+if ! gocyclo -over 11 -avg .
 then
     echo -e "${RED_BG}[FAIL]${NC} Functions/methods with high cyclomatic complexity detected"
     exit 1

--- a/storage.go
+++ b/storage.go
@@ -133,6 +133,21 @@ const (
 		  FROM new_reports
 		 WHERE updated_at < NOW() - $1::INTERVAL
 `
+
+	// Display older records from reported table
+	displayOldRecordsFromReportedTable = `
+                SELECT org_id, account_number, cluster, updated_at, 0
+		  FROM reported
+		 WHERE updated_at < NOW() - $1::INTERVAL
+		 ORDER BY updated_at
+`
+
+	// Delete older records from reported table
+	deleteOldRecordsFromReportedTable = `
+                DELETE
+		  FROM reported
+		 WHERE updated_at < NOW() - $1::INTERVAL
+`
 	// Value to be stored in notification_types table
 	insertInstantReport = `
                 INSERT INTO notification_types (id, value, frequency, comment)
@@ -206,6 +221,8 @@ type Storage interface {
 	GetLatestKafkaOffset() (KafkaOffset, error)
 	PrintNewReportsForCleanup(maxAge string) error
 	CleanupNewReports(maxAge string) (int, error)
+	PrintOldReportsForCleanup(maxAge string) error
+	CleanupOldReports(maxAge string) (int, error)
 }
 
 // DBStorage is an implementation of Storage interface that use selected SQL like database
@@ -521,13 +538,12 @@ func (storage DBStorage) GetLatestKafkaOffset() (KafkaOffset, error) {
 
 // PrintNewReportsForCleanup method prints all reports older than specified
 // relative time
-func (storage DBStorage) PrintNewReportsForCleanup(maxAge string) error {
+func (storage DBStorage) PrintNewReports(maxAge string, query string, tableName string) error {
 	log.Info().
 		Str(MaxAgeAttribute, maxAge).
-		Str("select statement", displayOldRecordsFromNewReportsTable).
-		Msg("PrintNewReportsForCleanup operation")
+		Str("select statement", query).
+		Msg("PrintReportsForCleanup operation")
 
-	query := displayOldRecordsFromNewReportsTable
 	rows, err := storage.connection.Query(query, maxAge)
 	if err != nil {
 		return err
@@ -567,21 +583,33 @@ func (storage DBStorage) PrintNewReportsForCleanup(maxAge string) error {
 			Str(ClusterNameMessage, clusterName).
 			Str(UpdatedAtMessage, updatedAtF).
 			Int(AgeMessage, age).
-			Msg("Old report from `new_reports` table")
+			Msg("Old report from `" + tableName + "` table")
 	}
 	return nil
 }
 
-// CleanupNewReports method deletes all reports older than specified
+// PrintNewReportsForCleanup method prints all reports from `new_reports` table
+// older than specified relative time
+func (storage DBStorage) PrintNewReportsForCleanup(maxAge string) error {
+	return storage.PrintNewReports(maxAge, displayOldRecordsFromNewReportsTable, "new_reports")
+}
+
+// PrintOldReportsForCleanup method prints all reports from `reported` table
+// older than specified relative time
+func (storage DBStorage) PrintOldReportsForCleanup(maxAge string) error {
+	return storage.PrintNewReports(maxAge, displayOldRecordsFromReportedTable, "reported")
+}
+
+// Cleanup method deletes all reports older than specified
 // relative time
-func (storage DBStorage) CleanupNewReports(maxAge string) (int, error) {
+func (storage DBStorage) Cleanup(maxAge string, statement string) (int, error) {
 	log.Info().
 		Str(MaxAgeAttribute, maxAge).
-		Str("delete statement", deleteOldRecordsFromNewReportsTable).
-		Msg("CleanupNewReports operation")
+		Str("delete statement", statement).
+		Msg("Cleanup operation")
 
 	// perform the SQL statement
-	result, err := storage.connection.Exec(deleteOldRecordsFromNewReportsTable, maxAge)
+	result, err := storage.connection.Exec(statement, maxAge)
 	if err != nil {
 		return 0, err
 	}
@@ -592,4 +620,16 @@ func (storage DBStorage) CleanupNewReports(maxAge string) (int, error) {
 		return 0, err
 	}
 	return int(affected), nil
+}
+
+// CleanupNewReports method deletes all reports from `new_reports` table older
+// than specified relative time
+func (storage DBStorage) CleanupNewReports(maxAge string) (int, error) {
+	return storage.Cleanup(maxAge, deleteOldRecordsFromNewReportsTable)
+}
+
+// CleanupOldReports method deletes all reports from `reported` table older
+// than specified relative time
+func (storage DBStorage) CleanupOldReports(maxAge string) (int, error) {
+	return storage.Cleanup(maxAge, deleteOldRecordsFromReportedTable)
 }

--- a/storage.go
+++ b/storage.go
@@ -536,8 +536,8 @@ func (storage DBStorage) GetLatestKafkaOffset() (KafkaOffset, error) {
 	return offset, err
 }
 
-// PrintNewReportsForCleanup method prints all reports older than specified
-// relative time
+// PrintNewReports method prints all reports from selected table older than
+// specified relative time
 func (storage DBStorage) PrintNewReports(maxAge string, query string, tableName string) error {
 	log.Info().
 		Str(MaxAgeAttribute, maxAge).

--- a/types.go
+++ b/types.go
@@ -37,6 +37,8 @@ type CliFlags struct {
 	showConfiguration             bool
 	printNewReportsForCleanup     bool
 	performNewReportsCleanup      bool
+	printOldReportsForCleanup     bool
+	performOldReportsCleanup      bool
 	maxAge                        string
 }
 


### PR DESCRIPTION
# Description

Ability to cleanup old records from `reported` table

Fixes #60 

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
