### PR TITLE
Fix environment variable typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ issue.py
 issues.py
 nw
 ccx-notification-writer
+
+shellcheck-stable

--- a/ccx_notification_writer.go
+++ b/ccx_notification_writer.go
@@ -63,7 +63,7 @@ const (
 
 // Configuration-related constants
 const (
-	configFileEnvVariableName = "NOTIFICATION_SERVICE_CONFIG_FILE"
+	configFileEnvVariableName = "CCX_NOTIFICATION_WRITER_CONFIG_FILE"
 	defaultConfigFileName     = "config"
 )
 

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -1,0 +1,23 @@
+[broker]
+address = "kafka:29092"
+topic = "ccx.ocp.results"
+group = "test-consumer-group"
+enabled = true
+
+[storage]
+db_driver = "postgres"
+pg_username = "user"
+pg_password = "password"
+pg_host = "localhost"
+pg_port = 5432
+pg_db_name = "notification"
+pg_params = "sslmode=disable"
+log_sql_queries = true
+
+[logging]
+debug = true
+log_level = ""
+
+[metrics]
+namespace = "notification_writer"
+address = ":8080"


### PR DESCRIPTION
# Description

There was a typo in the configuration environment variable. This change shouldn't affect [ccx-notification-writer.yml](https://github.com/RedHatInsights/e2e-deploy/blob/master/templates/ccx-data-pipeline/ccx-notification-writer.yml) at `e2e-deploy` as this env var is not used.

I also added a `config-devel.toml` to test it. Also ignored shellcheck binary as it is downloaded inside the repo in case you don't have it installed.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Ran `make test` and `before_commit`. Ran the binary with `config-devel.toml` and `-check-kafka` flag making sure that the port changes.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
