### PR TITLE
Update config_test.go with a typo in a test description

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -82,7 +82,7 @@ func TestLoadConfigurationNonEnvVarUnknownConfigFile(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-// TestLoadConfigurationBadConfigFile tests loading an unexisting config file when no environment variable is provided
+// TestLoadConfigurationBadConfigFile tests loading a bad config file when no environment variable is provided
 func TestLoadConfigurationBadConfigFile(t *testing.T) {
 	_, err := main.LoadConfiguration("", "tests/config3")
 	assert.Contains(t, err.Error(), `fatal error config file: While parsing config:`)


### PR DESCRIPTION
# Description

The comment I changed was copied from the previous test and it was wrong.

## Type of change

- Documentation update

## Testing steps

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
