### PR TITLE
[CCXDEV-7402] Fix random cpu limit on stage

### DIFF
--- a/deploy/ccx-notification-writer-db-cleaner.yaml
+++ b/deploy/ccx-notification-writer-db-cleaner.yaml
@@ -18,6 +18,7 @@ objects:
     failedJobsHistoryLimit: 2
     jobTemplate:
       spec:
+        activeDeadlineSeconds: 600
         template:
           spec:
             containers:


### PR DESCRIPTION
# Description

In stage env our completed cronjobs are counted into the CPU/mem quota. To not count the cronjobs into the quota, we need to use activeDeadlineSeconds for cronjobs to not count the completed jobs into quota.

The activeDeadlineSeconds stops a pod after the specified timeout if it does not complete earlier.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
