### PR TITLE
[CCXDEV-7949] Set proper appname for pod autoscaler

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -32,7 +32,7 @@ objects:
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment
-      name: ccx-notification-writer
+      name: ccx-notification-writer-instance
     targetCPUUtilizationPercentage: 80
 
 - apiVersion: cloud.redhat.com/v1alpha1

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -24,7 +24,7 @@ objects:
   apiVersion: autoscaling/v1
   metadata:
     labels:
-      app: ccx-notification-writer
+      app: ccx-data-pipeline
     name: ccx-notification-writer
   spec:
     minReplicas: ${{MIN_REPLICAS}}


### PR DESCRIPTION
# Description

This fixes too many OCP events 'not found' for ccx-notification-service POD autoscaler.