### PR TITLE
Configurable max_age for db-cleanup cronjob

### DIFF
--- a/deploy/clowdapp-db-cleaner.yaml
+++ b/deploy/clowdapp-db-cleaner.yaml
@@ -76,9 +76,8 @@ objects:
             - /bin/sh
             - '-c'
             - >-
-              ./ccx-notification-writer --old-reports-cleanup --max-age '8
-              days'; ./ccx-notification-writer --new-reports-cleanup
-              --max-age '8 days' 
+              ./ccx-notification-writer --old-reports-cleanup --max-age ${OLD_REPORTS_MAX_AGE};
+              ./ccx-notification-writer --new-reports-cleanup --max-age ${NEW_REPORTS_MAX_AGE}
 
 
 parameters:
@@ -114,3 +113,9 @@ parameters:
 - description: When the cronjob runs
   name: JOB_SCHEDULE
   value: 0 0 * * *
+- description: Maximum age for old reports cleanup
+  name: OLD_REPORTS_MAX_AGE
+  value: '8 days'
+- description: Maximum age for new reports cleanup
+  name: NEW_REPORTS_MAX_AGE
+  value: '8 days'


### PR DESCRIPTION
# Description

Make the max_age parameter configurable in the notification-db-cleanup deployment config.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
