### PR TITLE
Migration 0003 - populate event_targets table

### DIFF
--- a/mig_0003_populate_event_tables.go
+++ b/mig_0003_populate_event_tables.go
@@ -36,39 +36,10 @@ var mig0003PopulateEventTables = mig.Migration{
 				       (2, 'service log', 'the target of the report is the ServiceLog')
 
 		`)
-		if err != nil {
-			return err
-		}
-		_, err = tx.Exec(`
-			UPDATE reported
-			   SET event_type_id = 1
-			 WHERE event_type_id IS NULL
-		`)
-		if err != nil {
-			return err
-		}
-		_, err = tx.Exec(`
-			 ALTER TABLE reported
-			ALTER COLUMN event_type_id SET NOT NULL
-		`)
 		return err
 	},
 	StepDown: func(tx *sql.Tx, _ types.DBDriver) error {
-		_, err := tx.Exec(`
-			 ALTER TABLE reported 
-			ALTER COLUMN event_type_id DROP NOT NULL;
-		`)
-		if err != nil {
-			return err
-		}
-		_, err = tx.Exec(`
-			UPDATE reported
-			   SET event_type_id = NULL
-		`)
-		if err != nil {
-			return err
-		}
-		_, err = tx.Exec(`DELETE FROM event_targets`)
+		_, err := tx.Exec(`DELETE FROM event_targets`)
 		return err
 	},
 }


### PR DESCRIPTION
# Description

Simplify migration_003 to only create entries in the `event_targets` table. This should be a part of `migration_002`, but that is already deployed in production DB.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Migrated local DB

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
