### PR TITLE
Kafka credentials support

### DIFF
--- a/config.go
+++ b/config.go
@@ -114,6 +114,16 @@ type LoggingConfiguration struct {
 type BrokerConfiguration struct {
 	// Address represents Kafka address
 	Address string `mapstructure:"address" toml:"address"`
+	// SecurityProtocol represents the security protocol used by the broker
+	SecurityProtocol string `mapstructure:"security_protocol" toml:"security_protocol"`
+	// 	CertPath is the path to a file containing the certificate to be used with the broker
+	CertPath string `mapstructure:"cert_path" toml:"cert_path"`
+	// SaslMechanism is the SASL mechanism used for authentication
+	SaslMechanism string `mapstructure:"sasl_mechanism" toml:"sasl_mechanism"`
+	// SaslUsername is the username used in case of PLAIN mechanism
+	SaslUsername string `mapstructure:"sasl_username" toml:"sasl_username"`
+	// SaslPassword is the password used in case of PLAIN mechanism
+	SaslPassword string `mapstructure:"sasl_password" toml:"sasl_password"`
 	// Topic is name of Kafka topic
 	Topic string `mapstructure:"topic" toml:"topic"`
 	// Group is name of Kafka group
@@ -244,6 +254,17 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 			c.Broker.Address = fmt.Sprintf("%s:%d", broker.Hostname, *broker.Port)
 		} else {
 			c.Broker.Address = broker.Hostname
+		}
+
+		// SSL config
+		if broker.Authtype != nil {
+			c.Broker.SaslUsername = *broker.Sasl.Username
+			c.Broker.SaslPassword = *broker.Sasl.Password
+			c.Broker.SaslMechanism = *broker.Sasl.SaslMechanism
+
+			if caPath, err := clowder.LoadedConfig.KafkaCa(broker); err == nil {
+				c.Broker.CertPath = caPath
+			}
 		}
 	}
 

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,9 @@
 [broker]
 address = "localhost:9092"
+security_protocol = "PLAINTEXT"
+sasl_mechanism = "not-used"
+sasl_username = "not-used"
+sasl_password = "not-used"
 topic = "ccx.ocp.results"
 group = "test-consumer-group"
 enabled = true

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
 	github.com/prometheus/client_golang v1.12.1
-	github.com/redhatinsights/app-common-go v1.5.1
+	github.com/redhatinsights/app-common-go v1.6.3
 	github.com/rs/zerolog v1.21.0
 	github.com/spf13/viper v1.7.2-0.20210415161207-7fdb267c730d
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhatinsights/app-common-go v1.5.1 h1:M0HuhnP6oR1CzJsCjxlnxcFiEVeg5f6m3FvmdPFodkc=
-github.com/redhatinsights/app-common-go v1.5.1/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
+github.com/redhatinsights/app-common-go v1.6.3 h1:HhjDKLBqQM5i8Ii58WLi5hG+lTNaKgpAEnJ2vdVUJtw=
+github.com/redhatinsights/app-common-go v1.6.3/go.mod h1:6gzRyg8ZyejwMCksukeAhh2ZXOB3uHSmBsbP06fG2PQ=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=


### PR DESCRIPTION
# Description

Added support for Kafka SASL PLAIN authentication, in order to work with RHOSAK clusters

Fixes #CCXDEV-8702

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Run a RHOSAK cluster and configure the service to communicate with it propertly.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
