### PR TITLE
Migration 0004 - Update event_type_id column to 1 if null

### DIFF
--- a/mig_0004_update_reported_table_with_eventtype.go
+++ b/mig_0004_update_reported_table_with_eventtype.go
@@ -27,14 +27,10 @@ import (
 	types "github.com/RedHatInsights/insights-results-types"
 )
 
-// mig0003PopulateEventTables migration add all existing event targets into
-// `event_targets` table. Currently Notification Backend and ServiceLog targets
-// exist and will be inserted to the table.
-//
-// Also `reported` table content is changed by this migration: all existing
-// records are updated to contain foreign key to `event_target == notification
-// backend`.
-var mig0004PopulateEventTables = mig.Migration{
+// mig0004UpdateEventTypeIDInReportedTable migration mopdifies the reported
+// table, updating all records are updated to contain the value '1' in the
+// event_type_id column if it is currently null.
+var mig0004UpdateEventTypeIDInReportedTable = mig.Migration{
 	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
 		_, err := tx.Exec(`
 			UPDATE reported

--- a/migration.go
+++ b/migration.go
@@ -33,7 +33,7 @@ var migrations = []utils.Migration{
 	mig0001CreateEventTargetsTbl,
 	mig0002AddEventTargetCol,
 	mig0003PopulateEventTables,
-	mig0004PopulateEventTables,
+	mig0004UpdateEventTypeIDInReportedTable,
 }
 
 // All returns "migration" , the list of implemented utils.Migration


### PR DESCRIPTION
# Description

This migration follows up on [migration 0003](https://github.com/RedHatInsights/ccx-notification-writer/blob/master/mig_0003_populate_event_tables.go), setting the value of the `event_type_id` column of the `reported` table to 1 if null.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

local DB migration

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
