### PR TITLE
Get correct Kafka topic name from Clowder's LoadedConfig

### DIFF
--- a/config.go
+++ b/config.go
@@ -277,6 +277,7 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 		} else {
 			fmt.Println("warning: no broker configurations found in clowder config")
 		}
+		useCLowderTopics(&c.Broker)
 	}
 
 	if clowder.LoadedConfig.Database != nil {
@@ -289,4 +290,13 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 	}
 
 	return nil
+}
+
+func useCLowderTopics(c *BrokerConfiguration) {
+	// Get the correct topic name from clowder mapping if available
+	if clowderTopic, ok := clowder.KafkaTopics[c.Topic]; ok {
+		c.Topic = clowderTopic.Name
+	} else {
+		fmt.Printf("warning: no topic name found for topic %s in clowder configuration", c.Topic)
+	}
 }


### PR DESCRIPTION
# Description

Clowder's Kafka Topic representation contains two fields: `name` and `requiredName`. Up until now both had the same value, but in the managed Kafka instances, they can differ, and the `name` field should be used.

Fixes CCXDEV-9201

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
