### PR TITLE
Benchmarks for `DELETE` records from reported table with multiple indices

### DIFF
--- a/db_benchmark_test.go
+++ b/db_benchmark_test.go
@@ -1009,3 +1009,45 @@ func BenchmarkSelectOldLargeRecordsFromReportedTableV2(b *testing.B) {
 		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, noOpStatement,
 		initStatements, indices, report)
 }
+
+// BenchmarkDeleteOldEmptyRecordsFromReportedTableV1 tests the deletion statement
+// from reported table used inside CCX Notification Service
+func BenchmarkDeleteOldEmptyRecordsFromReportedTableV1(b *testing.B) {
+	// empty report
+	report := ``
+
+	// default init statements for reported table without event_type_id column
+	initStatements := []string{
+		dropTableReportedV1,
+		createTableReportedV1,
+	}
+
+	// all possible indices combinatiors for reported table without event_type_id column
+	indices := getIndicesForReportedTableV1()
+
+	// run benchmarks with various combination of indices
+	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
+		insertIntoReportedV1, noOpStatement, deleteOldRecordsFromReportedTableV1,
+		initStatements, indices, report)
+}
+
+// BenchmarkDeleteOldEmptyRecordsFromReportedTableV2 tests the deletion statement
+// from reported table used inside CCX Notification Service
+func BenchmarkDeleteOldEmptyRecordsFromReportedTableV2(b *testing.B) {
+	// empty report
+	report := ``
+
+	// default init statements for reported table without event_type_id column
+	initStatements := []string{
+		dropTableReportedV2,
+		createTableReportedV2,
+	}
+
+	// all possible indices combinatiors for reported table without event_type_id column
+	indices := getIndicesForReportedTableV2()
+
+	// run benchmarks with various combination of indices
+	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
+		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
+		initStatements, indices, report)
+}

--- a/db_benchmark_test.go
+++ b/db_benchmark_test.go
@@ -221,10 +221,6 @@ const (
                   FROM reported_benchmark_2
                  WHERE updated_at < NOW() - $1::INTERVAL
         `
-
-	// vacuuming statements for both tables used by benchmarks
-	vacuumTableReportedV1Statement = `vacuum reported_benchmark_1`
-	vacuumTableReportedV2Statement = `vacuum reported_benchmark_2`
 )
 
 // insertIntoReportedFunc type represents any function to be called to insert

--- a/db_benchmark_test.go
+++ b/db_benchmark_test.go
@@ -1093,3 +1093,45 @@ func BenchmarkDeleteOldSmallRecordsFromReportedTableV2(b *testing.B) {
 		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
 		initStatements, indices, report)
 }
+
+// BenchmarkDeleteOldMiddleRecordsFromReportedTableV1 tests the deletion statement
+// from reported table used inside CCX Notification Service
+func BenchmarkDeleteOldMiddleRecordsFromReportedTableV1(b *testing.B) {
+	// report with size over 4kB
+	report := readReport(b, middleReportInJSON)
+
+	// default init statements for reported table without event_type_id column
+	initStatements := []string{
+		dropTableReportedV1,
+		createTableReportedV1,
+	}
+
+	// all possible indices combinatiors for reported table without event_type_id column
+	indices := getIndicesForReportedTableV1()
+
+	// run benchmarks with various combination of indices
+	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
+		insertIntoReportedV1, noOpStatement, deleteOldRecordsFromReportedTableV1,
+		initStatements, indices, report)
+}
+
+// BenchmarkDeleteOldMiddleRecordsFromReportedTableV2 tests the deletion statement
+// from reported table used inside CCX Notification Service
+func BenchmarkDeleteOldMiddleRecordsFromReportedTableV2(b *testing.B) {
+	// report with size over 4kB
+	report := readReport(b, middleReportInJSON)
+
+	// default init statements for reported table without event_type_id column
+	initStatements := []string{
+		dropTableReportedV2,
+		createTableReportedV2,
+	}
+
+	// all possible indices combinatiors for reported table without event_type_id column
+	indices := getIndicesForReportedTableV2()
+
+	// run benchmarks with various combination of indices
+	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
+		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
+		initStatements, indices, report)
+}

--- a/db_benchmark_test.go
+++ b/db_benchmark_test.go
@@ -474,6 +474,12 @@ func runBenchmarkSelectOrDeleteFromReportedTable(b *testing.B, insertFunction in
 			if err != nil {
 				b.Fatal(err)
 			}
+			// fill-in the table again (no part of benchmark, so don't measure time there)
+			b.StopTimer()
+			for i := 0; i < reportsCount; i++ {
+				insertFunction(b, connection, i, report)
+			}
+			b.StartTimer()
 		}
 	}
 }

--- a/db_benchmark_test.go
+++ b/db_benchmark_test.go
@@ -1051,3 +1051,45 @@ func BenchmarkDeleteOldEmptyRecordsFromReportedTableV2(b *testing.B) {
 		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
 		initStatements, indices, report)
 }
+
+// BenchmarkDeleteOldSmallRecordsFromReportedTableV1 tests the deletion statement
+// from reported table used inside CCX Notification Service
+func BenchmarkDeleteOldSmallRecordsFromReportedTableV1(b *testing.B) {
+	// report with size over 2kB
+	report := readReport(b, smallReportInJSON)
+
+	// default init statements for reported table without event_type_id column
+	initStatements := []string{
+		dropTableReportedV1,
+		createTableReportedV1,
+	}
+
+	// all possible indices combinatiors for reported table without event_type_id column
+	indices := getIndicesForReportedTableV1()
+
+	// run benchmarks with various combination of indices
+	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
+		insertIntoReportedV1, noOpStatement, deleteOldRecordsFromReportedTableV1,
+		initStatements, indices, report)
+}
+
+// BenchmarkDeleteOldSmallRecordsFromReportedTableV2 tests the deletion statement
+// from reported table used inside CCX Notification Service
+func BenchmarkDeleteOldSmallRecordsFromReportedTableV2(b *testing.B) {
+	// report with size over 2kB
+	report := readReport(b, smallReportInJSON)
+
+	// default init statements for reported table without event_type_id column
+	initStatements := []string{
+		dropTableReportedV2,
+		createTableReportedV2,
+	}
+
+	// all possible indices combinatiors for reported table without event_type_id column
+	indices := getIndicesForReportedTableV2()
+
+	// run benchmarks with various combination of indices
+	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
+		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
+		initStatements, indices, report)
+}

--- a/db_benchmark_test.go
+++ b/db_benchmark_test.go
@@ -68,6 +68,8 @@ const (
 // Table reported V1 is reported table without event_type column and constraint for this column
 // Table reported V2 is reported table with event_type column and constraint for this column
 const (
+	noOpStatement = ``
+
 	dropTableReportedV1 = `DROP TABLE IF EXISTS reported_benchmark_1;`
 	dropTableReportedV2 = `DROP TABLE IF EXISTS reported_benchmark_2;`
 
@@ -205,6 +207,24 @@ const (
                  WHERE updated_at < NOW() - $1::INTERVAL
                  ORDER BY updated_at
         `
+
+	// SQL query used to display older records from reported table
+	deleteOldRecordsFromReportedTableV1 = `
+                DELETE
+                  FROM reported_benchmark_1
+                 WHERE updated_at < NOW() - $1::INTERVAL
+        `
+
+	// SQL query used to display older records from reported table
+	deleteOldRecordsFromReportedTableV2 = `
+                DELETE
+                  FROM reported_benchmark_2
+                 WHERE updated_at < NOW() - $1::INTERVAL
+        `
+
+	// vacuuming statements for both tables used by benchmarks
+	vacuumTableReportedV1Statement = `vacuum reported_benchmark_1`
+	vacuumTableReportedV2Statement = `vacuum reported_benchmark_2`
 )
 
 // insertIntoReportedFunc type represents any function to be called to insert
@@ -434,7 +454,7 @@ func runBenchmarkSelectOrDeleteFromReportedTable(b *testing.B, insertFunction in
 	// perform DB benchmark
 	for i := 0; i < b.N; i++ {
 		// perform benchmarks for SELECT statement (query)
-		if selectStatement != "" {
+		if selectStatement != noOpStatement {
 			rows, err := connection.Query(selectStatement, "8 days")
 			if err != nil {
 				b.Fatal(err)
@@ -449,7 +469,7 @@ func runBenchmarkSelectOrDeleteFromReportedTable(b *testing.B, insertFunction in
 			}
 		}
 		// perform benchmarks for DELETE statement
-		if deleteStatement != "" {
+		if deleteStatement != noOpStatement {
 			_, err := connection.Exec(deleteStatement, "8 days")
 			if err != nil {
 				b.Fatal(err)
@@ -833,7 +853,7 @@ func BenchmarkSelectOldEmptyRecordsFromReportedTableV1(b *testing.B) {
 
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
-		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, "",
+		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, noOpStatement,
 		initStatements, indices, report)
 }
 
@@ -854,7 +874,7 @@ func BenchmarkSelectOldEmptyRecordsFromReportedTableV2(b *testing.B) {
 
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
-		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, "",
+		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, noOpStatement,
 		initStatements, indices, report)
 }
 
@@ -875,7 +895,7 @@ func BenchmarkSelectOldSmallRecordsFromReportedTableV1(b *testing.B) {
 
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
-		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, "",
+		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, noOpStatement,
 		initStatements, indices, report)
 }
 
@@ -896,7 +916,7 @@ func BenchmarkSelectOldSmallRecordsFromReportedTableV2(b *testing.B) {
 
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
-		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, "",
+		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, noOpStatement,
 		initStatements, indices, report)
 }
 
@@ -917,7 +937,7 @@ func BenchmarkSelectOldMiddleRecordsFromReportedTableV1(b *testing.B) {
 
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
-		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, "",
+		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, noOpStatement,
 		initStatements, indices, report)
 }
 
@@ -938,7 +958,7 @@ func BenchmarkSelectOldMiddleRecordsFromReportedTableV2(b *testing.B) {
 
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
-		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, "",
+		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, noOpStatement,
 		initStatements, indices, report)
 }
 
@@ -959,7 +979,7 @@ func BenchmarkSelectOldLargeRecordsFromReportedTableV1(b *testing.B) {
 
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
-		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, "",
+		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, noOpStatement,
 		initStatements, indices, report)
 }
 
@@ -980,6 +1000,6 @@ func BenchmarkSelectOldLargeRecordsFromReportedTableV2(b *testing.B) {
 
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
-		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, "",
+		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, noOpStatement,
 		initStatements, indices, report)
 }

--- a/db_benchmark_test.go
+++ b/db_benchmark_test.go
@@ -1135,3 +1135,45 @@ func BenchmarkDeleteOldMiddleRecordsFromReportedTableV2(b *testing.B) {
 		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
 		initStatements, indices, report)
 }
+
+// BenchmarkDeleteOldLargeRecordsFromReportedTableV1 tests the deletion statement
+// from reported table used inside CCX Notification Service
+func BenchmarkDeleteOldLargeRecordsFromReportedTableV1(b *testing.B) {
+	// report with size over 8kB
+	report := readReport(b, largeReportInJSON)
+
+	// default init statements for reported table without event_type_id column
+	initStatements := []string{
+		dropTableReportedV1,
+		createTableReportedV1,
+	}
+
+	// all possible indices combinatiors for reported table without event_type_id column
+	indices := getIndicesForReportedTableV1()
+
+	// run benchmarks with various combination of indices
+	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
+		insertIntoReportedV1, noOpStatement, deleteOldRecordsFromReportedTableV1,
+		initStatements, indices, report)
+}
+
+// BenchmarkDeleteOldLargeRecordsFromReportedTableV2 tests the deletion statement
+// from reported table used inside CCX Notification Service
+func BenchmarkDeleteOldLargeRecordsFromReportedTableV2(b *testing.B) {
+	// report with size over 8kB
+	report := readReport(b, largeReportInJSON)
+
+	// default init statements for reported table without event_type_id column
+	initStatements := []string{
+		dropTableReportedV2,
+		createTableReportedV2,
+	}
+
+	// all possible indices combinatiors for reported table without event_type_id column
+	indices := getIndicesForReportedTableV2()
+
+	// run benchmarks with various combination of indices
+	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
+		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
+		initStatements, indices, report)
+}


### PR DESCRIPTION
# Description

Benchmarks for `DELETE` records from reported table with multiple indices

## Type of change

- Benchmarks (no changes in the code)

## Testing steps

Can be run locally

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
