### PR TITLE
Ability to specify records count for benchmarks

### DIFF
--- a/db_benchmark_test.go
+++ b/db_benchmark_test.go
@@ -34,8 +34,11 @@ package main_test
 // https://redhatinsights.github.io/ccx-notification-writer/packages/db_benchmark_test.html
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -226,6 +229,13 @@ const (
 // insertIntoReportedFunc type represents any function to be called to insert
 // records into reported table
 type insertIntoReportedFunc func(b *testing.B, connection *sql.DB, i int, report *string)
+
+// CLI flags that can be provided
+// (please note that in tests it is NOT NEEDED to parse flags)
+var minReportsParam = flag.Int("min-reports", 1, "minimal number of reports to be inserted into database (inclusive)")
+var maxReportsParam = flag.Int("max-reports", 10, "maximal number of reports to be inserted into database (exclusive)")
+var reportsStepParam = flag.Int("reports-step", 1, "steps between consecutive reports count")
+var reportsCountParam = flag.String("reports-count", "", "explicit reports count")
 
 // initLogging function initializes logging that's used internally by functions
 // from github.com/RedHatInsights/ccx-notification-writer package

--- a/db_benchmark_test.go
+++ b/db_benchmark_test.go
@@ -618,10 +618,8 @@ func benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(
 	deleteStatement string,
 	initStatements []string,
 	indices map[string][]string,
-	report string) {
-
-	// number of reports to be insterted into the table
-	var possibleReportsCount []int = []int{1, 100, 1000}
+	report string,
+	possibleReportsCount []int) {
 
 	// try all indices combinations
 	for description, indexStatements := range indices {
@@ -863,10 +861,13 @@ func BenchmarkSelectOldEmptyRecordsFromReportedTableV1(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV1()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, noOpStatement,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkSelectOldEmptyRecordsFromReportedTableV2 tests the query to reported
@@ -884,10 +885,13 @@ func BenchmarkSelectOldEmptyRecordsFromReportedTableV2(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV2()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, noOpStatement,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkSelectOldSmallRecordsFromReportedTableV1 tests the query to reported
@@ -905,10 +909,13 @@ func BenchmarkSelectOldSmallRecordsFromReportedTableV1(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV1()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, noOpStatement,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkSelectOldSmallRecordsFromReportedTableV2 tests the query to reported
@@ -926,10 +933,13 @@ func BenchmarkSelectOldSmallRecordsFromReportedTableV2(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV2()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, noOpStatement,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkSelectOldMiddleRecordsFromReportedTableV1 tests the query to reported
@@ -947,10 +957,13 @@ func BenchmarkSelectOldMiddleRecordsFromReportedTableV1(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV1()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, noOpStatement,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkSelectOldMiddleRecordsFromReportedTableV2 tests the query to reported
@@ -968,10 +981,13 @@ func BenchmarkSelectOldMiddleRecordsFromReportedTableV2(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV2()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, noOpStatement,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkSelectOldLargeRecordsFromReportedTableV1 tests the query to reported
@@ -989,10 +1005,13 @@ func BenchmarkSelectOldLargeRecordsFromReportedTableV1(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV1()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV1, displayOldRecordsFromReportedTableV1, noOpStatement,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkSelectOldLargeRecordsFromReportedTableV2 tests the query to reported
@@ -1010,10 +1029,13 @@ func BenchmarkSelectOldLargeRecordsFromReportedTableV2(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV2()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV2, displayOldRecordsFromReportedTableV2, noOpStatement,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkDeleteOldEmptyRecordsFromReportedTableV1 tests the deletion statement
@@ -1031,10 +1053,13 @@ func BenchmarkDeleteOldEmptyRecordsFromReportedTableV1(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV1()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV1, noOpStatement, deleteOldRecordsFromReportedTableV1,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkDeleteOldEmptyRecordsFromReportedTableV2 tests the deletion statement
@@ -1052,10 +1077,13 @@ func BenchmarkDeleteOldEmptyRecordsFromReportedTableV2(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV2()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkDeleteOldSmallRecordsFromReportedTableV1 tests the deletion statement
@@ -1073,10 +1101,13 @@ func BenchmarkDeleteOldSmallRecordsFromReportedTableV1(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV1()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV1, noOpStatement, deleteOldRecordsFromReportedTableV1,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkDeleteOldSmallRecordsFromReportedTableV2 tests the deletion statement
@@ -1094,10 +1125,13 @@ func BenchmarkDeleteOldSmallRecordsFromReportedTableV2(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV2()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkDeleteOldMiddleRecordsFromReportedTableV1 tests the deletion statement
@@ -1115,10 +1149,13 @@ func BenchmarkDeleteOldMiddleRecordsFromReportedTableV1(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV1()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV1, noOpStatement, deleteOldRecordsFromReportedTableV1,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkDeleteOldMiddleRecordsFromReportedTableV2 tests the deletion statement
@@ -1136,10 +1173,13 @@ func BenchmarkDeleteOldMiddleRecordsFromReportedTableV2(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV2()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkDeleteOldLargeRecordsFromReportedTableV1 tests the deletion statement
@@ -1157,10 +1197,13 @@ func BenchmarkDeleteOldLargeRecordsFromReportedTableV1(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV1()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV1, noOpStatement, deleteOldRecordsFromReportedTableV1,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }
 
 // BenchmarkDeleteOldLargeRecordsFromReportedTableV2 tests the deletion statement
@@ -1178,8 +1221,11 @@ func BenchmarkDeleteOldLargeRecordsFromReportedTableV2(b *testing.B) {
 	// all possible indices combinatiors for reported table without event_type_id column
 	indices := getIndicesForReportedTableV2()
 
+	// read number of reports to be inserted into the table under tests
+	reportsCount := readPossibleReportsCount()
+
 	// run benchmarks with various combination of indices
 	benchmarkSelectOrDeleteOldReportsFromReportedTableImpl(b,
 		insertIntoReportedV2, noOpStatement, deleteOldRecordsFromReportedTableV2,
-		initStatements, indices, report)
+		initStatements, indices, report, reportsCount)
 }

--- a/db_benchmark_test.go
+++ b/db_benchmark_test.go
@@ -405,7 +405,7 @@ func runBenchmarkInsertIntoReportedTable(b *testing.B, insertFunction insertInto
 	}
 
 	// good citizens cleanup properly
-	//defer execSQLStatement(b, connection, dropTableReportedV1)
+	// defer execSQLStatement(b, connection, dropTableReportedV1)
 
 	// time to start benchmark
 	b.ResetTimer()
@@ -437,7 +437,7 @@ func runBenchmarkSelectOrDeleteFromReportedTable(b *testing.B, insertFunction in
 	}
 
 	// good citizens cleanup properly
-	//defer execSQLStatement(b, connection, dropTableReportedV1)
+	// defer execSQLStatement(b, connection, dropTableReportedV1)
 
 	// fill-in the table (no part of benchmark, so don't measure time there)
 	for i := 0; i < reportsCount; i++ {

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -45,7 +45,7 @@ These three paramers can be used to create a sequence compatible with Python's `
 
 Additionally it is possible to specify inserted reports counts explicitly:
 
-1. `reports-step=1,2,5,1000
+1. `reports-count=1,2,5,1000
 
 Please note that CLI arguments for tests/benchmarks need to be prepended by `-args`
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -31,6 +31,34 @@ configuration is stored in
 [tests/benchmark.toml](https://github.com/RedHatInsights/ccx-notification-writer/blob/master/tests/benchmark.toml)
 file.
 
+### Number of records to be inserted into tested database table
+
+In order to be able to check time complexity of SELECT/INSERT/DELETE operations
+it is needed to have a technology to specify number of inserted records. It can
+be specified via the followin CLI arguments during test/benchmark invocation:
+
+1. `-min-reports`
+1. `-max-reports`
+1. `-reports-step`
+
+These three paramers can be used to create a sequence compatible with Python's `range` generator.
+
+Additionally it is possible to specify inserted reports counts explicitly:
+
+1. `reports-step=1,2,5,1000
+
+Please note that CLI arguments for tests/benchmarks need to be prepended by `-args`
+
+#### Examples
+
+```bash
+go test -run=^$
+go test -bench="BenchmarkDelete.*" -count=1 -benchtime=1s -timeout 100m -run=^$
+go test -bench="BenchmarkDelete.*" -count=1 -benchtime=2s -timeout 200m -run=^$$ -args -min-reports=3 -max-reports=7 -reports-step=2
+go test -bench="BenchmarkDelete.*" -count=1 -benchtime=2s -timeout 200m -run=^$$ -args -reports-count=1,2,5
+go test -bench="BenchmarkDelete.*" -count=1 -benchtime=2s -timeout 200m -run=^$$ -args -min-reports=1 -max-reports=10 -reports-step=2 -reports-count=1,2,5
+```
+
 ### Configuring remote database
 
 For benchmarking against remote database (which is real-world scenarion) the


### PR DESCRIPTION
# Description

Ability to specify records count for benchmarks

## Type of change

- New feature (non-breaking change which adds functionality)
- Benchmarks (no changes in the code)
- Documentation update

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
