### PR TITLE
Fix max_age parameter in db-cleaner deployment file

### DIFF
--- a/deploy/clowdapp-db-cleaner.yaml
+++ b/deploy/clowdapp-db-cleaner.yaml
@@ -76,8 +76,8 @@ objects:
             - /bin/sh
             - '-c'
             - >-
-              ./ccx-notification-writer --old-reports-cleanup --max-age ${OLD_REPORTS_MAX_AGE};
-              ./ccx-notification-writer --new-reports-cleanup --max-age ${NEW_REPORTS_MAX_AGE}
+              ./ccx-notification-writer --old-reports-cleanup --max-age '${OLD_REPORTS_MAX_AGE}';
+              ./ccx-notification-writer --new-reports-cleanup --max-age '${NEW_REPORTS_MAX_AGE}'
 
 
 parameters:


### PR DESCRIPTION
# Description

`max-age` parameter expects a string value, and currently receives an integer as it is not wrapped within quotes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
