### PR TITLE
[CCXDEV-8201] Disable minimum-three-replicas kube-linter check

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -39,6 +39,8 @@ objects:
   kind: ClowdApp
   metadata:
     name: ccx-notification-writer
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: "This app doesn't have that much traffic"
   spec:
     envName: ${ENV_NAME}
     dependencies:


### PR DESCRIPTION
# Description

Disable the minimum-three-replicas kubelinter check.

## Type of change

- Deployment (no changes in the code)

## Testing steps

I tested this with the content-service and worked.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
