### PR TITLE
GetBrokerConfiguration accepts a reference to configuration structure

### DIFF
--- a/ccx_notification_writer.go
+++ b/ccx_notification_writer.go
@@ -100,7 +100,7 @@ func showAuthors() {
 
 // showConfiguration function displays actual configuration.
 func showConfiguration(configuration ConfigStruct) {
-	brokerConfig := GetBrokerConfiguration(configuration)
+	brokerConfig := GetBrokerConfiguration(&configuration)
 	log.Info().
 		Str(brokerAddress, brokerConfig.Address).
 		Str("Security protocol", brokerConfig.SecurityProtocol).
@@ -140,7 +140,7 @@ func tryToConnectToKafka(configuration ConfigStruct) (int, error) {
 	log.Info().Msg("Checking connection to Kafka")
 
 	// prepare broker configuration
-	brokerConfiguration := GetBrokerConfiguration(configuration)
+	brokerConfiguration := GetBrokerConfiguration(&configuration)
 
 	log.Info().Str("broker address", brokerConfiguration.Address).Msg(brokerAddress)
 
@@ -359,7 +359,7 @@ func startService(configuration ConfigStruct) (int, error) {
 	}
 
 	// prepare broker
-	brokerConfiguration := GetBrokerConfiguration(configuration)
+	brokerConfiguration := GetBrokerConfiguration(&configuration)
 
 	// if broker is disabled, simply don't start it
 	if brokerConfiguration.Enabled {

--- a/config.go
+++ b/config.go
@@ -230,7 +230,7 @@ func GetLoggingConfiguration(configuration ConfigStruct) LoggingConfiguration {
 }
 
 // GetBrokerConfiguration returns broker configuration
-func GetBrokerConfiguration(configuration ConfigStruct) BrokerConfiguration {
+func GetBrokerConfiguration(configuration *ConfigStruct) BrokerConfiguration {
 	return configuration.Broker
 }
 

--- a/config_benchmark_test.go
+++ b/config_benchmark_test.go
@@ -34,7 +34,7 @@ func mustLoadBenchmarkConfiguration(b *testing.B) main.ConfigStruct {
 
 // BenchmarkGetMetricsConfigurarion measures the speed of
 // GetMetricsConfiguration function from the main module.
-func BenchmarkGetMetricsConfigurarion(b *testing.B) {
+func _BenchmarkGetMetricsConfigurarion(b *testing.B) {
 	initLogging()
 	configuration := mustLoadBenchmarkConfiguration(b)
 
@@ -47,6 +47,25 @@ func BenchmarkGetMetricsConfigurarion(b *testing.B) {
 			b.Fatal("Wrong configuration: namespace = '" + m.Namespace + "'")
 		}
 		if m.Address != ":8080" {
+			b.Fatal("Wrong configuration: address = '" + m.Address + "'")
+		}
+		b.StartTimer()
+	}
+
+}
+
+// BenchmarkGetBrokerConfigurarion measures the speed of
+// GetBrokerConfiguration function from the main module.
+func BenchmarkGetMetricsConfigurarion(b *testing.B) {
+	initLogging()
+	configuration := mustLoadBenchmarkConfiguration(b)
+
+	for i := 0; i < b.N; i++ {
+		// call benchmarked function
+		m := main.GetBrokerConfiguration(&configuration)
+
+		b.StopTimer()
+		if m.Address != "kafka:29092" {
 			b.Fatal("Wrong configuration: address = '" + m.Address + "'")
 		}
 		b.StartTimer()

--- a/config_benchmark_test.go
+++ b/config_benchmark_test.go
@@ -34,7 +34,7 @@ func mustLoadBenchmarkConfiguration(b *testing.B) main.ConfigStruct {
 
 // BenchmarkGetMetricsConfigurarion measures the speed of
 // GetMetricsConfiguration function from the main module.
-func _BenchmarkGetMetricsConfigurarion(b *testing.B) {
+func BenchmarkGetMetricsConfigurarion(b *testing.B) {
 	initLogging()
 	configuration := mustLoadBenchmarkConfiguration(b)
 
@@ -56,7 +56,7 @@ func _BenchmarkGetMetricsConfigurarion(b *testing.B) {
 
 // BenchmarkGetBrokerConfigurarion measures the speed of
 // GetBrokerConfiguration function from the main module.
-func BenchmarkGetMetricsConfigurarion(b *testing.B) {
+func BenchmarkGetBrokerConfigurarion(b *testing.B) {
 	initLogging()
 	configuration := mustLoadBenchmarkConfiguration(b)
 

--- a/config_test.go
+++ b/config_test.go
@@ -115,7 +115,7 @@ func TestLoadBrokerConfiguration(t *testing.T) {
 	config, err := main.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	brokerCfg := main.GetBrokerConfiguration(config)
+	brokerCfg := main.GetBrokerConfiguration(&config)
 
 	assert.Equal(t, "localhost:29092", brokerCfg.Address)
 	assert.Equal(t, "ccx_test_notifications", brokerCfg.Topic)
@@ -212,7 +212,7 @@ func TestLoadConfigurationNoKafkaBroker(t *testing.T) {
 	assert.NoError(t, err, "Failed loading configuration file")
 
 	// retrieve broker configuration that was just loaded
-	brokerCfg := main.GetBrokerConfiguration(config)
+	brokerCfg := main.GetBrokerConfiguration(&config)
 
 	// check broker configuration
 	assert.Equal(t, "localhost:29092", brokerCfg.Address)
@@ -248,7 +248,7 @@ func TestLoadConfigurationKafkaBrokerEmptyConfig(t *testing.T) {
 	assert.NoError(t, err, "Failed loading configuration file")
 
 	// retrieve broker configuration that was just loaded
-	brokerCfg := main.GetBrokerConfiguration(config)
+	brokerCfg := main.GetBrokerConfiguration(&config)
 
 	// check broker configuration
 	assert.Equal(t, "", brokerCfg.Address)
@@ -285,7 +285,7 @@ func TestLoadConfigurationKafkaBrokerNoPort(t *testing.T) {
 	assert.NoError(t, err, "Failed loading configuration file")
 
 	// retrieve broker configuration that was just loaded
-	brokerCfg := main.GetBrokerConfiguration(config)
+	brokerCfg := main.GetBrokerConfiguration(&config)
 
 	// check broker configuration
 	// no port should be set
@@ -325,7 +325,7 @@ func TestLoadConfigurationKafkaBrokerPort(t *testing.T) {
 	assert.NoError(t, err, "Failed loading configuration file")
 
 	// retrieve broker configuration that was just loaded
-	brokerCfg := main.GetBrokerConfiguration(config)
+	brokerCfg := main.GetBrokerConfiguration(&config)
 
 	// check broker configuration
 	assert.Equal(t, "test:1234", brokerCfg.Address)
@@ -368,7 +368,7 @@ func TestLoadConfigurationKafkaBrokerAuthConfigMissingSASL(t *testing.T) {
 	assert.NoError(t, err, "Failed loading configuration file")
 
 	// retrieve broker configuration that was just loaded
-	brokerCfg := main.GetBrokerConfiguration(config)
+	brokerCfg := main.GetBrokerConfiguration(&config)
 
 	// check broker configuration
 	assert.Equal(t, "test:1234", brokerCfg.Address)
@@ -428,7 +428,7 @@ func TestLoadConfigurationKafkaBrokerAuthConfig(t *testing.T) {
 	assert.NoError(t, err, "Failed loading configuration file")
 
 	// retrieve broker configuration that was just loaded
-	brokerCfg := main.GetBrokerConfiguration(config)
+	brokerCfg := main.GetBrokerConfiguration(&config)
 
 	// check broker configuration
 	assert.Equal(t, "test:1234", brokerCfg.Address)
@@ -477,7 +477,7 @@ func TestLoadConfigurationKafkaTopicUpdatedFromClowder(t *testing.T) {
 	config, err := main.LoadConfiguration("CCX_NOTIFICATION_WRITER_CONFIG_FILE", "tests/config2")
 	assert.NoError(t, err, "Failed loading configuration file")
 
-	brokerCfg := main.GetBrokerConfiguration(config)
+	brokerCfg := main.GetBrokerConfiguration(&config)
 	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Address)
 	assert.Equal(t, newTopicName, brokerCfg.Topic)
 
@@ -487,7 +487,7 @@ func TestLoadConfigurationKafkaTopicUpdatedFromClowder(t *testing.T) {
 	config, err = main.LoadConfiguration("CCX_NOTIFICATION_WRITER_CONFIG_FILE", "tests/config1")
 	assert.NoError(t, err, "Failed loading configuration file")
 
-	brokerCfg = main.GetBrokerConfiguration(config)
+	brokerCfg = main.GetBrokerConfiguration(&config)
 	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Address)
 	assert.Equal(t, topicName, brokerCfg.Topic)
 }


### PR DESCRIPTION
# Description

GetBrokerConfiguration accepts a reference to configuration structure

## Type of change

- Refactor (refactoring code, removing useless files)
- Benchmarks (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
