### PR TITLE
Pass consumer configuration by reference

### DIFF
--- a/ccx_notification_writer.go
+++ b/ccx_notification_writer.go
@@ -364,7 +364,7 @@ func startService(configuration ConfigStruct) (int, error) {
 
 	// if broker is disabled, simply don't start it
 	if brokerConfiguration.Enabled {
-		err := startConsumer(brokerConfiguration, storage)
+		err := startConsumer(&brokerConfiguration, storage)
 		if err != nil {
 			log.Error().Err(err)
 			return ExitStatusConsumerError, err
@@ -377,7 +377,7 @@ func startService(configuration ConfigStruct) (int, error) {
 }
 
 // startConsumer function starts the Kafka consumer.
-func startConsumer(brokerConfiguration BrokerConfiguration, storage Storage) error {
+func startConsumer(brokerConfiguration *BrokerConfiguration, storage Storage) error {
 	consumer, err := NewConsumer(brokerConfiguration, storage)
 	if err != nil {
 		log.Error().Err(err).Msg("Construct broker failed")

--- a/consumer.go
+++ b/consumer.go
@@ -126,7 +126,7 @@ type KafkaConsumer struct {
 var DefaultSaramaConfig *sarama.Config
 
 // NewConsumer constructs new implementation of Consumer interface
-func NewConsumer(brokerConfiguration BrokerConfiguration, storage Storage) (*KafkaConsumer, error) {
+func NewConsumer(brokerConfiguration *BrokerConfiguration, storage Storage) (*KafkaConsumer, error) {
 	return NewWithSaramaConfig(brokerConfiguration, DefaultSaramaConfig, storage)
 }
 

--- a/consumer.go
+++ b/consumer.go
@@ -132,7 +132,7 @@ func NewConsumer(brokerConfiguration *BrokerConfiguration, storage Storage) (*Ka
 
 // NewWithSaramaConfig constructs new implementation of Consumer interface with custom sarama config
 func NewWithSaramaConfig(
-	brokerConfiguration BrokerConfiguration,
+	brokerConfiguration *BrokerConfiguration,
 	saramaConfig *sarama.Config,
 	storage Storage,
 ) (*KafkaConsumer, error) {
@@ -554,7 +554,7 @@ func parseMessage(messageValue []byte) (IncomingMessage, error) {
 	return deserialized, nil
 }
 
-func saramaConfigFromBrokerConfig(brokerConfiguration BrokerConfiguration) (*sarama.Config, error) {
+func saramaConfigFromBrokerConfig(brokerConfiguration *BrokerConfiguration) (*sarama.Config, error) {
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V0_10_2_0
 

--- a/consumer.go
+++ b/consumer.go
@@ -151,7 +151,7 @@ func NewWithSaramaConfig(
 	}
 
 	consumer := &KafkaConsumer{
-		Configuration:                        brokerConfiguration,
+		Configuration:                        *brokerConfiguration,
 		ConsumerGroup:                        consumerGroup,
 		Storage:                              storage,
 		numberOfSuccessfullyConsumedMessages: 0,

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -68,7 +68,7 @@ func TestNewConsumerBadBroker(t *testing.T) {
 	dummyStorage := main.NewFromConnection(nil, 1)
 
 	// try to construct new consumer
-	mockConsumer, err := main.NewConsumer(brokerConfiguration, dummyStorage)
+	mockConsumer, err := main.NewConsumer(&brokerConfiguration, dummyStorage)
 
 	// check that error is really reported
 	assert.Contains(t, err.Error(), expectedErr)
@@ -100,7 +100,7 @@ func TestNewConsumerLocalBroker(t *testing.T) {
 	dummyStorage := main.NewFromConnection(nil, 1)
 
 	// try to construct new consumer
-	mockConsumer, err := main.NewConsumer(brokerConfiguration, dummyStorage)
+	mockConsumer, err := main.NewConsumer(&brokerConfiguration, dummyStorage)
 
 	// check that error is really reported
 	assert.Contains(t, err.Error(), expectedErr)
@@ -132,7 +132,7 @@ func TestNewConsumerSaramaConfig(t *testing.T) {
 	dummyStorage := main.NewFromConnection(nil, 1)
 
 	// try to construct new consumer
-	mockConsumer, err := main.NewConsumer(brokerConfiguration, dummyStorage)
+	mockConsumer, err := main.NewConsumer(&brokerConfiguration, dummyStorage)
 
 	// check that error is really reported
 	assert.Contains(t, err.Error(), expectedErr)
@@ -165,7 +165,7 @@ func TestNewConsumerTLSEnabled(t *testing.T) {
 	dummyStorage := main.NewFromConnection(nil, 1)
 
 	// try to construct new consumer
-	mockConsumer, err := main.NewConsumer(brokerConfiguration, dummyStorage)
+	mockConsumer, err := main.NewConsumer(&brokerConfiguration, dummyStorage)
 
 	// check that error is really reported
 	assert.Contains(t, err.Error(), expectedErr)
@@ -201,7 +201,7 @@ func TestNewConsumerSASLEnabled(t *testing.T) {
 	dummyStorage := main.NewFromConnection(nil, 1)
 
 	// try to construct new consumer
-	mockConsumer, err := main.NewConsumer(brokerConfiguration, dummyStorage)
+	mockConsumer, err := main.NewConsumer(&brokerConfiguration, dummyStorage)
 
 	// check that error is really reported
 	assert.Contains(t, err.Error(), expectedErr)
@@ -234,7 +234,7 @@ func TestNewConsumerCertPath(t *testing.T) {
 	dummyStorage := main.NewFromConnection(nil, 1)
 
 	// try to construct new consumer
-	mockConsumer, err := main.NewConsumer(brokerConfiguration, dummyStorage)
+	mockConsumer, err := main.NewConsumer(&brokerConfiguration, dummyStorage)
 
 	// check that error is really reported
 	assert.Contains(t, err.Error(), expectedErr)
@@ -267,7 +267,7 @@ func TestNewConsumerInvalidCertPath(t *testing.T) {
 	dummyStorage := main.NewFromConnection(nil, 1)
 
 	// try to construct new consumer
-	mockConsumer, err := main.NewConsumer(brokerConfiguration, dummyStorage)
+	mockConsumer, err := main.NewConsumer(&brokerConfiguration, dummyStorage)
 
 	// check that error is really reported
 	assert.Contains(t, err.Error(), expectedErr)


### PR DESCRIPTION
# Description

Trivial: pass consumer configuration by reference

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
