### PR TITLE
Checks if none configuration getters are not mutable

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -531,3 +531,23 @@ func TestGetLoggingConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetLoggingConfiguration must not be mutable")
 }
+
+// TestGetBrokerConfigurationIsImmutable checks if function
+// GetBrokerConfiguration is not mutable
+func TestGetBrokerConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_WRITER_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := main.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	main.GetBrokerConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetBrokerConfiguration must not be mutable")
+}

--- a/config_test.go
+++ b/config_test.go
@@ -491,3 +491,23 @@ func TestLoadConfigurationKafkaTopicUpdatedFromClowder(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Address)
 	assert.Equal(t, topicName, brokerCfg.Topic)
 }
+
+// TestGetStorageConfigurationIsImmutable checks if function
+// GetStorageConfiguration is not mutable
+func TestGetStorageConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_WRITER_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := main.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	main.GetStorageConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetStorageConfiguration must not be mutable")
+}

--- a/config_test.go
+++ b/config_test.go
@@ -511,3 +511,23 @@ func TestGetStorageConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetStorageConfiguration must not be mutable")
 }
+
+// TestGetLoggingConfigurationIsImmutable checks if function
+// GetLoggingConfiguration is not mutable
+func TestGetLoggingConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_WRITER_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := main.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	main.GetLoggingConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetLoggingConfiguration must not be mutable")
+}

--- a/config_test.go
+++ b/config_test.go
@@ -551,3 +551,23 @@ func TestGetBrokerConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetBrokerConfiguration must not be mutable")
 }
+
+// TestGetMetricsConfigurationIsImmutable checks if function
+// GetMetricsConfiguration is not mutable
+func TestGetMetricsConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_WRITER_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := main.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	main.GetMetricsConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetMetricsConfiguration must not be mutable")
+}


### PR DESCRIPTION
# Description

Checks if none configuration getters are not mutable

## Type of change

- Unit tests (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
