### PR TITLE
Migration to create `read_errors` table

### DIFF
--- a/mig_0005_create_read_errors_table.go
+++ b/mig_0005_create_read_errors_table.go
@@ -1,0 +1,63 @@
+// Copyright 2023 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// Generated documentation is available at:
+// https://pkg.go.dev/github.com/RedHatInsights/ccx-notification-writer/
+//
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/ccx-notification-writer/packages/mig_0005_create_read_errors_table.html
+
+import (
+	"database/sql"
+	mig "github.com/RedHatInsights/insights-operator-utils/migrations"
+	types "github.com/RedHatInsights/insights-results-types"
+	"github.com/rs/zerolog/log"
+)
+
+// mig0001CreateEventTargetsTbl migration creates table named `event_targets`.
+// This table contains all event receivers, for example Notification Backend
+// and ServiceLog
+var mig0005CreateReadErrorsTable = mig.Migration{
+	StepUp: func(tx *sql.Tx, _ types.DBDriver) error {
+		log.Debug().Msg("Executing mig0005CreateReadErrorsTable stepUp function")
+		query := `
+			CREATE TABLE IF NOT EXISTS read_errors (
+			    error_id    serial primary key,
+			    org_id      integer not null,
+			    cluster     character(36) not null,
+			    updated_at  timestamp not null,
+			    error_text  varchar(1000) not null,
+			    created_at  timestamp not null,
+			    FOREIGN KEY(org_id, cluster, updated_at)
+			    REFERENCES new_reports(org_id, cluster, updated_at),
+			    UNIQUE(error_id, org_id, cluster, updated_at)
+			)`
+		_, err := executeQuery(tx, query)
+		if err == nil {
+			log.Debug().Msg("Table event_targets created successfully")
+		}
+		return err
+	},
+	StepDown: func(tx *sql.Tx, _ types.DBDriver) error {
+		log.Debug().Msg("Executing mig0005CreateReadErrorsTable stepDown function")
+		query := "DROP TABLE read_errors"
+		_, err := executeQuery(tx, query)
+		if err == nil {
+			log.Debug().Msg("Table event_targets dropped successfully")
+		}
+		return err
+	},
+}

--- a/mig_0005_create_read_errors_table.go
+++ b/mig_0005_create_read_errors_table.go
@@ -47,7 +47,7 @@ var mig0005CreateReadErrorsTable = mig.Migration{
 			)`
 		_, err := executeQuery(tx, query)
 		if err == nil {
-			log.Debug().Msg("Table event_targets created successfully")
+			log.Debug().Msg("Table read_errors created successfully")
 		}
 		return err
 	},
@@ -56,7 +56,7 @@ var mig0005CreateReadErrorsTable = mig.Migration{
 		query := "DROP TABLE read_errors"
 		_, err := executeQuery(tx, query)
 		if err == nil {
-			log.Debug().Msg("Table event_targets dropped successfully")
+			log.Debug().Msg("Table read_errors dropped successfully")
 		}
 		return err
 	},

--- a/migration.go
+++ b/migration.go
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022 Red Hat, Inc
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ var migrations = []utils.Migration{
 	mig0002AddEventTargetCol,
 	mig0003PopulateEventTables,
 	mig0004UpdateEventTypeIDInReportedTable,
+	mig0005CreateReadErrorsTable,
 }
 
 // All returns "migration" , the list of implemented utils.Migration

--- a/migration_test.go
+++ b/migration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022 Red Hat, Inc
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -401,6 +401,41 @@ func Test0004MigrationStepDown2(t *testing.T) {
 
 	// migration should end with error
 	assert.Error(t, main.Migrate(connection, 3), mockedError)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
+func Test0005MigrationStepUp(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{"version"})
+	rows.AddRow("4")
+
+	count := sqlmock.NewRows([]string{"count"})
+	count.AddRow("1")
+
+	resultCreate := sqlmock.NewResult(0, 1)
+	resultUpdate := sqlmock.NewResult(1, 1)
+
+	// expected query performed by tested function
+	expectedQuery0 := "SELECT COUNT\\(\\*\\) FROM migration_info;"
+	expectedQuery1 := "SELECT version FROM migration_info;"
+	expectedCreate := "CREATE TABLE IF NOT EXISTS read_errors .*"
+	expectedUpdate := "UPDATE migration_info SET version=\\$1;"
+
+	mock.ExpectQuery(expectedQuery0).WillReturnRows(count)
+	mock.ExpectQuery(expectedQuery1).WillReturnRows(rows)
+	mock.ExpectBegin()
+	mock.ExpectExec(expectedCreate).WillReturnResult(resultCreate)
+	mock.ExpectExec(expectedUpdate).WillReturnResult(resultUpdate)
+	mock.ExpectCommit()
+	mock.ExpectClose()
+
+	utils.Set(main.All())
+	assert.NoError(t, main.Migrate(connection, 5))
 
 	// check if all expectations were met
 	checkAllExpectations(t, mock)

--- a/migration_test.go
+++ b/migration_test.go
@@ -440,3 +440,38 @@ func Test0005MigrationStepUp(t *testing.T) {
 	// check if all expectations were met
 	checkAllExpectations(t, mock)
 }
+
+func Test0005MigrationStepDown(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{"version"})
+	rows.AddRow("5")
+
+	count := sqlmock.NewRows([]string{"count"})
+	count.AddRow("1")
+
+	resultDrop := sqlmock.NewResult(0, 1)
+	resultUpdate := sqlmock.NewResult(1, 1)
+
+	// expected query performed by tested function
+	expectedQuery0 := "SELECT COUNT\\(\\*\\) FROM migration_info;"
+	expectedQuery1 := "SELECT version FROM migration_info;"
+	expectedDrop := "DROP TABLE read_errors"
+	expectedUpdate := "UPDATE migration_info SET version=\\$1;"
+
+	mock.ExpectQuery(expectedQuery0).WillReturnRows(count)
+	mock.ExpectQuery(expectedQuery1).WillReturnRows(rows)
+	mock.ExpectBegin()
+	mock.ExpectExec(expectedDrop).WillReturnResult(resultDrop)
+	mock.ExpectExec(expectedUpdate).WillReturnResult(resultUpdate)
+	mock.ExpectCommit()
+	mock.ExpectClose()
+
+	utils.Set(main.All())
+	assert.NoError(t, main.Migrate(connection, 4))
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}


### PR DESCRIPTION
# Description

Migration to create `read_errors` table

Fixes https://issues.redhat.com/browse/CCXDEV-9498

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

Migration can be started from command line using the standard option `-migrate 5`.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
