### PR TITLE
[CCXDEV-11471] Upgrade the postgres database that is used in ephemeral

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -153,7 +153,7 @@ objects:
     database:
       # the DB name should match to app-interface DB name without specifying environment
       name: ccx-notification-db
-      version: 12
+      version: 15
     kafkaTopics:
       - topicName: ${INCOMING_TOPIC}
         partitions: 1


### PR DESCRIPTION
# Description

We are planning on migrating from Postgres v11 to v15. Let's first update the version that clowder uses for ephemeral deployments. This will tell us whether our iqe tests pass for this version.

This won't affect stage nor prod as this `version` is just used for ephemeral.

Part of #CCXDEV-11471

## Type of change
- Configuration update

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
