### PR TITLE
Augment deadline of the cronjob

### DIFF
--- a/deploy/clowdapp-db-cleaner.yaml
+++ b/deploy/clowdapp-db-cleaner.yaml
@@ -23,7 +23,7 @@ objects:
         restartPolicy: Never
         concurrencyPolicy: Forbid
         # In PROD 1 cronjob takes around 45 min. Deadline set to 60 mins.
-        activeDeadlineSeconds: 3600
+        activeDeadlineSeconds: 36000
         suspend: ${{SUSPEND_JOB}}
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
# Description

As part of [CCXDEV-11734](https://issues.redhat.com/browse/CCXDEV-11734), I realised that the current deadline is not enough to cleanup the database due to the accumulated data. Bumping it up temporarily.

## Type of change

- Configuration update

## Testing steps

N /A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
