### PR TITLE
Hack for updating the migration_info.version value in the database

### DIFF
--- a/types.go
+++ b/types.go
@@ -41,6 +41,7 @@ type CliFlags struct {
 	MigrationInfo                 bool
 	MaxAge                        string
 	PerformMigrations             string
+	UpdateMigrationInfo           string
 }
 
 // RequestID data type is used to store the request ID supplied in input Kafka


### PR DESCRIPTION
# Description

Hack to allow the direct update of the database value for "migration_info" table, "version" column.

Reasoning: In our stage environment, we don't know how but that field was reset to 0, making the notification-writer unable to start due to a failure when trying the migration to "latest" database version.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Testing steps

Run against a local database

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
