### PR TITLE
Using a different base image for the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN umask 0022 && \
     make build && \
     chmod a+x ccx-notification-writer
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8-5
 
 COPY --from=builder /opt/app-root/src/ccx-notification-writer .
 


### PR DESCRIPTION
# Description

Test to check if using ubi-micro image as base could help to prevent CVEs while doesn't affect to the service

## Type of change

- Bump-up dependent library (no changes in the code)
- Security fix in dependent library (no changes in the code)
- Security fix in dependent library (changes made in the code)

## Testing steps

Regular CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
