### PR TITLE
Add read_errors table cleanup functionality

### DIFF
--- a/ccx_notification_writer.go
+++ b/ccx_notification_writer.go
@@ -376,10 +376,10 @@ func performOldReportsCleanup(configuration *ConfigStruct, cliFlags CliFlags) (i
 	return ExitStatusOK, nil
 }
 
-// printOldReportsForCleanup function print all reports stored in `reported`
+// printReadErrorsForCleanup function print all reports stored in `read_errors`
 // table that are older than specified max age.
 //
-// See also: performOldReportsCleanup
+// See also: performReadErrorsForCleanup
 func printReadErrorsForCleanup(configuration *ConfigStruct, cliFlags CliFlags) (int, error) {
 	// prepare the storage
 	storageConfiguration := GetStorageConfiguration(configuration)
@@ -398,7 +398,7 @@ func printReadErrorsForCleanup(configuration *ConfigStruct, cliFlags CliFlags) (
 	return ExitStatusOK, nil
 }
 
-// performOldReportsCleanup function deletes all reports from `read_errors` table
+// performReadErrorsCleanup function deletes all reports from `read_errors` table
 // that are older than specified max age.
 func performReadErrorsCleanup(configuration *ConfigStruct, cliFlags CliFlags) (int, error) {
 	// prepare the storage

--- a/mock_storage_test.go
+++ b/mock_storage_test.go
@@ -40,6 +40,8 @@ type MockStorage struct {
 	cleanupNewReportsCalled         int
 	printOldReportsForCleanupCalled int
 	cleanupOldReportsCalled         int
+	printReadErrorsForCleanupCalled int
+	cleanupReadReportsCalled        int
 	closeCalled                     int
 	writeReportCalled               int
 }
@@ -57,6 +59,8 @@ func NewMockStorage() MockStorage {
 		cleanupNewReportsCalled:         0,
 		printOldReportsForCleanupCalled: 0,
 		cleanupOldReportsCalled:         0,
+		printReadErrorsForCleanupCalled: 0,
+		cleanupReadReportsCalled:        0,
 		closeCalled:                     0,
 		writeReportCalled:               0,
 	}
@@ -163,6 +167,24 @@ func (storage *MockStorage) PrintOldReportsForCleanup(maxAge string) error {
 // CleanupOldReports is a mocked reimplementation of the real CleanupOldReports
 // method.
 func (storage *MockStorage) CleanupOldReports(maxAge string) (int, error) {
+	storage.cleanupOldReportsCalled++
+
+	// return number of cleaned records + no error
+	return 1, nil
+}
+
+// PrintReadErrorsForCleanup is a mocked reimplementation of the real
+// PrintReadErrorsForCleanup method.
+func (storage *MockStorage) PrintReadErrorsForCleanup(maxAge string) error {
+	storage.printReadErrorsForCleanupCalled++
+
+	// return no error
+	return nil
+}
+
+// CleanupReadErrors is a mocked reimplementation of the real CleanupReadErrors
+// method.
+func (storage *MockStorage) CleanupReadErrors(maxAge string) (int, error) {
 	storage.cleanupOldReportsCalled++
 
 	// return number of cleaned records + no error

--- a/types.go
+++ b/types.go
@@ -38,6 +38,8 @@ type CliFlags struct {
 	PerformNewReportsCleanup      bool
 	PrintOldReportsForCleanup     bool
 	PerformOldReportsCleanup      bool
+	PrintReadErrorsForCleanup     bool
+	PerformReadErrorsCleanup      bool
 	MigrationInfo                 bool
 	MaxAge                        string
 	PerformMigrations             string


### PR DESCRIPTION
# Description

Add option to cleanup `read_errors` table (and print what rows would be deleted using the `-print-read-erros-for-cleanup` option)

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

- Tested manually
- Updated BDDs (CI should pass when https://github.com/RedHatInsights/insights-behavioral-spec/pull/499 is merged)

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
