### PR TITLE
[CCXDEV-11745] Use -read-errors-cleanup functionality in cleaner cronjob

### DIFF
--- a/deploy/clowdapp-db-cleaner.yaml
+++ b/deploy/clowdapp-db-cleaner.yaml
@@ -77,7 +77,8 @@ objects:
             - '-c'
             - >-
               ./ccx-notification-writer --old-reports-cleanup --max-age '${OLD_REPORTS_MAX_AGE}';
-              ./ccx-notification-writer --new-reports-cleanup --max-age '${NEW_REPORTS_MAX_AGE}'
+              ./ccx-notification-writer --new-reports-cleanup --max-age '${NEW_REPORTS_MAX_AGE}';
+              ./ccx-notification-writer --read-errors-cleanup --max-age '${NEW_REPORTS_MAX_AGE}'
 
 
 parameters:


### PR DESCRIPTION
# Description

Use the `-read-errors-cleanup` functionality in db-cleaner cronjob so we can ensure the DB is not constantly growing due to this table.

Fixes CCXDEV_11745

## Type of change

- Configuration update

## Testing steps

Stage

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
