### PR TITLE
[CCXDEV-11745] Make cleaner fail if any of the cleanup operations fail

### DIFF
--- a/deploy/clowdapp-db-cleaner.yaml
+++ b/deploy/clowdapp-db-cleaner.yaml
@@ -76,8 +76,8 @@ objects:
             - /bin/sh
             - '-c'
             - >-
-              ./ccx-notification-writer --old-reports-cleanup --max-age '${OLD_REPORTS_MAX_AGE}';
-              ./ccx-notification-writer --new-reports-cleanup --max-age '${NEW_REPORTS_MAX_AGE}';
+              ./ccx-notification-writer --old-reports-cleanup --max-age '${OLD_REPORTS_MAX_AGE}' &&
+              ./ccx-notification-writer --new-reports-cleanup --max-age '${NEW_REPORTS_MAX_AGE}' &&
               ./ccx-notification-writer --read-errors-cleanup --max-age '${NEW_REPORTS_MAX_AGE}'
 
 


### PR DESCRIPTION
# Description

Change how the db-cleaner operations are chained so it stops when an error occurs. This way, the error is propagated to the pod and we can know about it.

Fixes CCXDEC-11745

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Configuration update

## Testing steps

Tested locally, and CI should pass

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
