### PR TITLE
[CCXDEV-14553] Fix typo in deployment

### DIFF
--- a/deploy/clowdapp-db-cleaner.yaml
+++ b/deploy/clowdapp-db-cleaner.yaml
@@ -86,7 +86,7 @@ objects:
             - /bin/sh
             - '-c'
             - >-
-              ./ccx-notification-writer --truncate-old-report &&
+              ./ccx-notification-writer --truncate-old-reports &&
               ./ccx-notification-writer --new-reports-cleanup --max-age '${NEW_REPORTS_MAX_AGE}' &&
               ./ccx-notification-writer --read-errors-cleanup --max-age '${NEW_REPORTS_MAX_AGE}'
 


### PR DESCRIPTION
# Description

Stage is failing with:

```
flag provided but not defined: -truncate-old-report
Usage of ./ccx-notification-writer:
  -authors
    	show authors
  -check-kafka
    	check connection to Kafka
  -db-cleanup
    	perform database cleanup
  -db-drop-tables
    	drop all tables from database
  -db-init
    	perform database initialization
  -db-init-migration
    	initialize migration
  -max-age string
    	max age for displaying/cleaning old records
  -migrate string
    	set database version
  -migration-info
    	prints migration info
  -new-reports-cleanup
    	perform new reports clean up
  -old-reports-cleanup
    	perform old reports clean up
  -print-new-reports-for-cleanup
    	print new reports to be cleaned up
  -print-old-reports-for-cleanup
    	print old reports to be cleaned up
  -print-read-errors-for-cleanup
    	print records from read_errors table to be cleaned up
  -read-errors-cleanup
    	perform clean up of read_errors table
  -show-configuration
    	show configuration
  -truncate-old-reports
    	truncate the reported table
  -version
    	show version
```

## Type of change

- Configuration update

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
