### PR TITLE
[CCXDEV-16243] Update Codecov integration to v5 with unit-tests flag

### DIFF
--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -38,6 +38,8 @@ jobs:
         run: ./check_coverage.sh
       - name: Display code coverage
         run: make coverage
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
+          fail_ci_if_error: false


### PR DESCRIPTION
# Description

- Update `codecov/codecov-action` from v4 to v5
- Add `flags: unit-tests` for coverage categorization
- Add `fail_ci_if_error: false` to prevent CI failures if Codecov is unreachable

Fixes CCXDEV-16243

## Type of change

- Configuration update